### PR TITLE
feat: add favorites feature and persistence

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Persist a value in localStorage. On mount, it attempts to read an existing
+ * entry for the given key and falls back to the provided initial value.
+ * Whenever the value changes, it serializes the value back into localStorage.
+ */
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Ignore write errors (e.g. storage disabled).
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}


### PR DESCRIPTION
Cette pull request ajoute une fonctionnalité de favoris à l'application, permettant aux utilisateurs de marquer des vidéos comme favorites et de les sauvegarder en local. Elle introduit un hook `useLocalStorage` pour persister des états dans le `localStorage`, un contexte `FavoritesContext` pour gérer les favoris (ajout, suppression, export/import au format JSON, nettoyage), une page **Mes favoris** avec liste filtrable et boutons d'export/import, l'intégration de la route `/favorites` et d'un badge de compteur dans la navigation, ainsi que des boutons étoile sur les cartes/vidéos. Cette PR corrige également quelques bugs de mise à jour de l'URL et améliore l'accessibilité (aria-labels).